### PR TITLE
added forwarders to mailcow

### DIFF
--- a/services/mailcow/mailcow_installation.sh
+++ b/services/mailcow/mailcow_installation.sh
@@ -54,6 +54,14 @@ if ! ./generate_config.sh; then
     log_info "Error al generar el archivo de configuracion"
 fi
 
+cat <<EOF >> /etc/mailcow-docker-config/mailcow-dockerized/data/conf/unbound/unbound.conf
+forward-zone:
+  name: "."
+  forward-addr: 172.31.9.254
+  forward-addr: 172.31.9.255
+EOF
+
+
 log_info "Iniciando mailcow..."
 if ! docker compose -f ./docker-compose.yml up -d; then
     log_info "Error al iniciar mailcow"


### PR DESCRIPTION
# 📌 Títol de la Pull Request
<!-- Ex: Configuració bàsica del servidor Openfire -->

Afegit que configuri els forwarders apuntant al slaves de DNS de la escola

---

## 🛠️ Què s’ha fet

<!--
Ex:
- Instal·lat i configurat Openfire al servidor amb IP 172.30.15.10
- Creat comptes d'usuari amb format nom@grupg.loc
- Verificat accés des de client Spark
-->

---

## 🔍 Com provar-ho

<!--
Ex:
1. Obrir el navegador i accedir a http://172.30.15.10:9090
2. Iniciar sessió amb un usuari creat (ex: anna@grupg.loc)
3. Fer proves d'enviament de missatges entre dos clients Spark
-->

---

## ✅ Verificació

- [ ] Funciona com s’esperava
- [ ] Provat amb companys o dispositius
- [ ] La configuració segueix l’esquema de xarxa

<!--
Marca amb una X les opcions que s'han completat.
-->

---

## 💬 Notes o dubtes

<!--
Ex:
- El client Linphone a Android no es connectava per problema de ports.
- Falten alguns usuaris per crear però la configuració bàsica ja funciona.
-->
